### PR TITLE
docs: fix typo

### DIFF
--- a/hyperpay-firebase-payments/PREINSTALL.md
+++ b/hyperpay-firebase-payments/PREINSTALL.md
@@ -9,7 +9,7 @@ This extension supports the following use cases:
 
 This extension uses the following Firebase services which may have associated charges:
 
-- Cloud Funtions
+- Cloud Functions
 
 This extensions also uses the following third-party services:
 


### PR DESCRIPTION
functions instead of funtions